### PR TITLE
Hooks cleanup

### DIFF
--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -73,7 +73,7 @@ function areHookInputsEqual(nextDeps, prevDeps) {
 
 let uniqueCounter = 0;
 
-function useTracker(reactiveFn, deps) {
+function useTracker(reactiveFn, deps, cleanup) {
   const previousDeps = useRef();
   const computation = useRef();
   const trackerData = useRef();
@@ -85,6 +85,7 @@ function useTracker(reactiveFn, deps) {
       computation.current.stop();
       computation.current = null;
     }
+    if (cleanup) cleanup();
   };
 
   // this is called like at componentWillMount and componentWillUpdate equally

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -78,7 +78,6 @@ function useTracker(reactiveFn, deps, cleanup) {
   const computation = useRef();
   const trackerData = useRef();
   const cleanupRef = useRef();
-  cleanupRef.current = cleanup;
 
   const [, forceUpdate] = useState();
 
@@ -134,6 +133,11 @@ function useTracker(reactiveFn, deps, cleanup) {
       })
     ));
   }
+
+  // NOTE: Make sure to set cleanupRef AFTER a possible dispose invokes the last one, because
+  // when/if deps change, we'll likely have a new cleanup method comint with it. So we want
+  // to invoke the last current one before we reset it.
+  cleanupRef.current = cleanup;
 
   // stop the computation on unmount only
   useEffect(() => {

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -77,6 +77,8 @@ function useTracker(reactiveFn, deps, cleanup) {
   const previousDeps = useRef();
   const computation = useRef();
   const trackerData = useRef();
+  const cleanupRef = useRef();
+  cleanupRef.current = cleanup;
 
   const [, forceUpdate] = useState();
 
@@ -85,7 +87,9 @@ function useTracker(reactiveFn, deps, cleanup) {
       computation.current.stop();
       computation.current = null;
     }
-    if (cleanup) cleanup();
+    if (cleanupRef.current) {
+      cleanupRef.current();
+    }
   };
 
   // this is called like at componentWillMount and componentWillUpdate equally


### PR DESCRIPTION
This PR adds a cleanup method to the `useTracker` hook. This cleanup function can be used to allow for easier cleanups after a hook has been used, and discarded.

Here are two examples - a useSubscription hook, and a useSession hook, implemented both with and without. Without first:

```js
// without cleanup, I have to use useEffect, which is cumbersome:

export const useSubscription = (name, ...rest) => {
  let handle
  const isReady = useTracker(
    () => {
      handle = Meteor.subscribe(name, ...rest)
      return handle.ready()
    },
    [name, ...rest]
  )
  useEffect(() => () => handle.stop(), [handle]) // cumbersome
  return isReady
}

export const useSession = (name, defaultValue, cleanup) => {
  const value = useTracker(() => {
    Session.setDefault(name, defaultValue)
    return Session.get(name)
  }, [name, defaultValue])
  // cumbersome
  const cleanupRef = useRef()
  cleanupRef.current = cleanup
  useEffect(() => {
    if (cleanupRef.current) {
      return cleanupRef.current
    }
  }, []) // cumbersome
  return [
    value,
    (val) => Session.set(name, val)
  ]
}
```

With cleanup next:

```js
export const useSubscription = (name, ...rest) => {
  let handle
  const isReady = useTracker(
    () => {
      handle = Meteor.subscribe(name, ...rest)
      return handle.ready()
    },
    [name, ...rest],
    () => { handle.stop() }
  )
  return isReady
}

export const useSession = (name, defaultValue, cleanup) => {
  const value = useTracker(() => {
    Session.setDefault(name, defaultValue)
    return Session.get(name)
  }, [name, defaultValue], cleanup)
  return [
    value,
    (val) => Session.set(name, val)
  ]
}
```

```js
// the useSession use case (cleaning up Meteor Session values is ... hacky)
const [myVal, setMyVal] = useSession('myVal', '', () => delete Session.keys['myVal'])
```