### PR TITLE
Hooks

### DIFF
--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -114,11 +114,13 @@ function useTracker(reactiveFn, deps) {
           // Additional cycles will follow the normal computation behavior.
           runReactiveFn();
         } else {
-          // Only run reactiveFn if the hooks have not change, or are not falsy.
-          if (areHookInputsEqual(deps, refs.previousDeps)) {
+          // Only run reactiveFn if the deps or are not falsy.
+          if (!deps || !refs.previousDeps) {
+            // Dispose early, if refs are falsy - we'll rebuild and run on the next render.
+            dispose();
+          } else {
             runReactiveFn();
           }
-          // If deps have changed or are falsy, let the reactiveFn run on next render.
           // use a uniqueCounter to trigger a state change to force a re-render
           forceUpdate(++uniqueCounter);
         }

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -74,16 +74,14 @@ function areHookInputsEqual(nextDeps, prevDeps) {
 let uniqueCounter = 0;
 
 function useTracker(reactiveFn, deps) {
-  const previousDeps = useRef();
-  const computation = useRef();
-  const trackerData = useRef();
+  const { current: refs } = useRef({});
 
   const [, forceUpdate] = useState();
 
   const dispose = () => {
-    if (computation.current) {
-      computation.current.stop();
-      computation.current = null;
+    if (refs.computation) {
+      refs.computation.stop();
+      refs.computation = null;
     }
   };
 
@@ -91,7 +89,7 @@ function useTracker(reactiveFn, deps) {
   // in order to support render calls with synchronous data from the reactive computation
   // if prevDeps or deps are not set areHookInputsEqual always returns false
   // and the reactive functions is always called
-  if (!areHookInputsEqual(deps, previousDeps.current)) {
+  if (!areHookInputsEqual(deps, refs.previousDeps)) {
     // if we are re-creating the computation, we need to stop the old one.
     dispose();
 
@@ -100,17 +98,17 @@ function useTracker(reactiveFn, deps) {
     // In that case, we want to opt out of the normal behavior of nested
     // Computations, where if the outer one is invalidated or stopped,
     // it stops the inner one.
-    computation.current = Tracker.nonreactive(() => (
+    refs.computation = Tracker.nonreactive(() => (
       Tracker.autorun((c) => {
         // This will capture data synchronously on first run (and after deps change).
         // Additional cycles will follow the normal computation behavior.
         const data = reactiveFn();
         if (Meteor.isDevelopment) checkCursor(data);
-        trackerData.current = data;
+        refs.trackerData = data;
 
         if (c.firstRun) {
           // store the deps for comparison on next render
-          previousDeps.current = deps;
+          refs.previousDeps = deps;
         } else {
           // use a uniqueCounter to trigger a state change to force a re-render
           forceUpdate(++uniqueCounter);
@@ -133,7 +131,7 @@ function useTracker(reactiveFn, deps) {
     return dispose;
   }, []);
 
-  return trackerData.current;
+  return refs.trackerData;
 }
 
 // When rendering on the server, we don't want to use the Tracker.

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -114,9 +114,8 @@ function useTracker(reactiveFn, deps) {
           // Additional cycles will follow the normal computation behavior.
           runReactiveFn();
         } else {
-          // Only run reactiveFn if the deps or are not falsy.
-          if (!deps || !refs.previousDeps) {
-            // Dispose early, if refs are falsy - we'll rebuild and run on the next render.
+          // If deps are falsy, stop computation and let next render handle reactiveFn.
+          if (!refs.previousDeps) {
             dispose();
           } else {
             runReactiveFn();


### PR DESCRIPTION
- Condenses refs into 1 `useRef`.
- Avoids running reactiveFn in asynchronous block, if it will run synchronously next render anyway.